### PR TITLE
fix: support stat on the root path

### DIFF
--- a/s3_fs.go
+++ b/s3_fs.go
@@ -237,6 +237,11 @@ func (fs *Fs) Rename(oldname, newname string) error {
 // Stat returns a FileInfo describing the named file.
 // If there is an error, it will be of type *os.PathError.
 func (fs *Fs) Stat(name string) (os.FileInfo, error) {
+	// Special case because you can not HeadObject on the bucket itself.
+	if name == "/" {
+		return NewFileInfo(name, true, 0, time.Unix(0, 0)), nil
+	}
+
 	out, err := fs.client.HeadObject(context.Background(), &s3.HeadObjectInput{
 		Bucket: aws.String(fs.bucket),
 		Key:    aws.String(name),

--- a/s3_test.go
+++ b/s3_test.go
@@ -588,6 +588,24 @@ func TestFileStat(t *testing.T) {
 			t.Fatal("Wrong file mode")
 		}
 	}
+
+	t.Run("can safely stat on /", func(t *testing.T) {
+		stat, err := fs.Stat("/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !stat.IsDir() {
+			t.Fatal("/ should be a directory")
+		}
+
+		if stat.Name() != "/" {
+			t.Fatalf("wanted /, got %q", stat.Name())
+		}
+
+		if stat.Mode() != 0755 {
+			t.Fatal("Wrong mode")
+		}
+	})
 }
 
 func testCreateFile(t *testing.T, fs afero.Fs, name string, content string) {


### PR DESCRIPTION
Add a special case for the root path `/`. This indidicates the bucket
itself, however, the S3 API doesn't currently support the HEAD operation
for the bucket itself.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>